### PR TITLE
Style for smaller screen

### DIFF
--- a/config.server.example.js
+++ b/config.server.example.js
@@ -2,6 +2,7 @@ export default {
     port: 8888,
     messagebird: '',
     server: 'https://kino.dr-kobros.com',
+    api: 'https://www.finnkino.fi',
     db: {
         some: 'parameter',
     }

--- a/src/components/App.pcss
+++ b/src/components/App.pcss
@@ -20,11 +20,12 @@ $font-size: 20px;
         background-color: rgb(255, 255, 255);
         color: rgb(0, 0, 0);
         font-size: $font-size;
-        padding: 2rem;
+        padding: 1.5rem;
         font-family: Lato;
 
         max-width: 640px;
         min-width: 320px;
+        margin: 0 auto;
     }
 
     label {
@@ -37,7 +38,20 @@ $font-size: 20px;
         margin: 0.25rem 0;
     }
 
+    button {
+        border-radius: 4px;
+        background: #F6D800;
+        border: 1px solid #333;
+        margin-bottom: 2rem;
+    }
+
     [disabled] {
         opacity: .5;
+    }
+
+    canvas {
+        height: auto !important;
+        width: 100% !important;
+        max-width: 300px;
     }
 }

--- a/src/components/EventInfo.pcss
+++ b/src/components/EventInfo.pcss
@@ -36,7 +36,6 @@
         @media (max-width: 350px) {
             font-size: 1.1rem;
         }
-        /* font-size: 1.1rem; */
     }
 
 }

--- a/src/components/EventInfo.pcss
+++ b/src/components/EventInfo.pcss
@@ -10,7 +10,19 @@
         margin: 1rem 0;
 
         th, td {
-            padding: .25rem;
+            padding: .30rem .25rem;
+        }
+
+        tr:first-child {
+            th, td {
+                padding-top: .5rem
+            }
+        }
+
+        tr:last-child {
+            th, td {
+                padding-bottom: .5rem
+            }
         }
 
         th {
@@ -20,6 +32,11 @@
         td {
             text-align: left;
         }
+
+        @media (max-width: 350px) {
+            font-size: 1.1rem;
+        }
+        /* font-size: 1.1rem; */
     }
 
 }

--- a/src/components/Ticket.pcss
+++ b/src/components/Ticket.pcss
@@ -3,9 +3,6 @@
 }
 
 .qrContainer {
-    margin: 2em 0;
+    margin: 2rem 0;
     text-align: center;
-
 }
-
-


### PR DESCRIPTION
- Make QR code’s size adaptable a.k.a. responsive
- Apply Finnkino’s yellow on send SMS button and remove default iOS
  stylings (button text was completely unreadable on iPhone 5)
- Give little bit of breathing room for tabular data (the box at the
  top)
